### PR TITLE
Fixed checkstyle suppressions invalid problem on windows

### DIFF
--- a/ligradle/checkstyle/suppressions.xml
+++ b/ligradle/checkstyle/suppressions.xml
@@ -3,5 +3,5 @@
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
-  <suppress files="/generated/" checks=".*"/>
+  <suppress files="[\\/]generated[\\/]" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
When I built the project on my Windows computer, the Checkstyle suppressions were invalid. And I fixed it with [this](https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/filters/SuppressiuonFilter.html).