### PR TITLE
Add regression test for issue #157

### DIFF
--- a/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
+++ b/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
@@ -208,11 +208,11 @@ public class TestEventHandler {
     assertTrue(!emitterThread.isAlive());
     verify(writer).close();
 
-    fs.delete(jobDir, true);
+    Utils.cleanupHDFSPath(fs.getConf(), jobDir);
   }
 
   @AfterClass
   public void cleanUp() throws IOException {
-    fs.delete(jobDir, true);
+    Utils.cleanupHDFSPath(fs.getConf(), jobDir);
   }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
+++ b/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
@@ -187,25 +187,14 @@ public class TestEventHandler {
       return result;
     }).when(eventHandlerThread).interrupt();
 
-    Thread emitterThread = new Thread(() -> {
-      // Ensure thread isn't blocked on writeEvent() after calling stop()
-      while (!Thread.currentThread().isInterrupted()) {
-        eventHandlerThread.emitEvent(eEventWrapper);
-      }
-    });
-
     eventHandlerThread.start();
     eventHandlerThread.stop(jobDir, metadata);
     eventHandlerThread.join();
-
-    emitterThread.interrupt();
-    emitterThread.join();
 
     if (gotUnexpectedInterrupt[0]) {
       fail("Unexpected interrupt.");
     }
     assertTrue(!eventHandlerThread.isAlive());
-    assertTrue(!emitterThread.isAlive());
     verify(writer).close();
 
     Utils.cleanupHDFSPath(fs.getConf(), jobDir);

--- a/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
+++ b/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
@@ -187,17 +187,19 @@ public class TestEventHandler {
       return result;
     }).when(eventHandlerThread).interrupt();
 
-    eventHandlerThread.start();
-    eventHandlerThread.stop(jobDir, metadata);
-    eventHandlerThread.join();
+    try {
+      eventHandlerThread.start();
+      eventHandlerThread.stop(jobDir, metadata);
+      eventHandlerThread.join();
+    } finally {
+      Utils.cleanupHDFSPath(fs.getConf(), jobDir);
+    }
 
     if (gotUnexpectedInterrupt[0]) {
       fail("Unexpected interrupt.");
     }
     assertTrue(!eventHandlerThread.isAlive());
     verify(writer).close();
-
-    Utils.cleanupHDFSPath(fs.getConf(), jobDir);
   }
 
   @AfterClass

--- a/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
+++ b/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
@@ -5,11 +5,16 @@
 package com.linkedin.tony.events;
 
 import com.linkedin.tony.models.JobMetadata;
+import com.linkedin.tony.util.HistoryFileUtils;
 import com.linkedin.tony.util.Utils;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.avro.file.DataFileWriter;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -22,11 +27,14 @@ import org.testng.annotations.Test;
 import static com.linkedin.tony.util.ParserUtils.parseEvents;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
-
+import org.mockito.internal.util.reflection.FieldSetter;
 
 public class TestEventHandler {
   private FileSystem fs = null;
@@ -144,6 +152,63 @@ public class TestEventHandler {
     assertEquals(eventQueue.size(), 4);
     eventHandlerThread.drainQueue(eventQueue, writer); // should drain the queue
     assertEquals(eventQueue.size(), 0);
+  }
+
+  @Test
+  public void testCleanUp() throws IOException, NoSuchFieldException, SecurityException,
+      TimeoutException, InterruptedException {
+    final boolean[] gotUnexpectedInterrupt = new boolean[] { false };
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    DataFileWriter<Event> writer = mock(DataFileWriter.class);
+    doAnswer(invocation -> {
+      try {
+        latch.await(5, TimeUnit.SECONDS); // Should unlock after interrupt is sent
+      } catch (InterruptedException e) {
+        gotUnexpectedInterrupt[0] = true;
+      }
+      return null;
+    }).when(writer).close();
+
+    Path inProgressHistFile = new Path(jobDir, HistoryFileUtils.generateFileName(metadata));
+    fs.create(inProgressHistFile);
+    eventHandlerThread = new EventHandler(fs, eventQueue);
+    FieldSetter.setField(eventHandlerThread,
+        eventHandlerThread.getClass().getDeclaredField("dataFileWriter"),
+        writer);
+    FieldSetter.setField(eventHandlerThread,
+        eventHandlerThread.getClass().getDeclaredField("inProgressHistFile"),
+        inProgressHistFile);
+
+    eventHandlerThread = spy(eventHandlerThread);
+    doAnswer(invocation -> {
+      Object result = invocation.callRealMethod();
+      latch.countDown();
+      return result;
+    }).when(eventHandlerThread).interrupt();
+
+    Thread emitterThread = new Thread(() -> {
+      // Ensure thread isn't blocked on writeEvent() after calling stop()
+      while (!Thread.currentThread().isInterrupted()) {
+        eventHandlerThread.emitEvent(eEventWrapper);
+      }
+    });
+
+    eventHandlerThread.start();
+    eventHandlerThread.stop(jobDir, metadata);
+    eventHandlerThread.join();
+
+    emitterThread.interrupt();
+    emitterThread.join();
+
+    if (gotUnexpectedInterrupt[0]) {
+      fail("Unexpected interrupt.");
+    }
+    assertTrue(!eventHandlerThread.isAlive());
+    assertTrue(!emitterThread.isAlive());
+    verify(writer).close();
+
+    fs.delete(jobDir, true);
   }
 
   @AfterClass


### PR DESCRIPTION
This test ensures that when `interrupt()` is called, the EventHandler
thread is not calling `dataFileWriter.close()`.

In order to have a reproducable test and avoid flakyness, we mock the
following methods to ensure the order and timming of the race condition:

- `dataFileWriter.close()` is locked on a latch until an `interrupt()`
is sent, if that interrupt happens inside this call, it will cause an
assertion fail;
- `interrupt()` unlocks that latch after executing the real
implementation;
- `eventHandlerThread` requires `dataFileWriter` to be set with the
mock, as well as `inProgressHistFile` to be set with a real path, to
pass some checks during `stop()`.

On my fork, I have branch `test-before-fix-157` to validate that this 
test fails on the commit before the fix, with the assertion fail on 
unexpected interrupt. Branch `test-157` contains the fix, allowing the 
test to pass.
