### PR TITLE
Rename tony.worker.timeout to tony.task.executor.execution-timeout-ms

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -109,7 +109,7 @@ public class ApplicationMaster {
 
   // Container info
   private int amRetryCount;
-  private long workerTimeout;
+  private long executionTimeout;
   private String hdfsClasspath;
   private int amPort;
   private ByteBuffer allTokens;
@@ -256,8 +256,8 @@ public class ApplicationMaster {
 
     appTimeout = tonyConf.getInt(TonyConfigurationKeys.APPLICATION_TIMEOUT,
                                  TonyConfigurationKeys.DEFAULT_APPLICATION_TIMEOUT);
-    workerTimeout = tonyConf.getInt(TonyConfigurationKeys.WORKER_TIMEOUT,
-        TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
+    executionTimeout = tonyConf.getInt(TonyConfigurationKeys.TASK_EXECUTION_TIMEOUT,
+        TonyConfigurationKeys.DEFAULT_TASK_EXECUTION_TIMEOUT);
     hdfsClasspath = cliParser.getOptionValue("hdfs_classpath");
     amRetryCount = tonyConf.getInt(TonyConfigurationKeys.AM_RETRY_COUNT,
         TonyConfigurationKeys.DEFAULT_AM_RETRY_COUNT);
@@ -808,7 +808,7 @@ public class ApplicationMaster {
     String taskCommand = tonyConf.get(TonyConfigurationKeys.getExecuteCommandKey(Constants.AM_NAME),
                 tonyConf.get(TonyConfigurationKeys.getContainerExecuteCommandKey()));
     LOG.info("Executing command: " + taskCommand);
-    int exitCode = Utils.executeShell(taskCommand, workerTimeout, extraEnv);
+    int exitCode = Utils.executeShell(taskCommand, executionTimeout, extraEnv);
 
     preprocessExitCode = exitCode;
     preprocessFinished = true;

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -254,8 +254,8 @@ public class TaskExecutor {
     amPort = Integer.parseInt(System.getenv(Constants.AM_PORT));
 
     tonyConf.addResource(new Path(Constants.TONY_FINAL_XML));
-    timeOut = tonyConf.getInt(TonyConfigurationKeys.WORKER_TIMEOUT,
-        TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
+    timeOut = tonyConf.getInt(TonyConfigurationKeys.TASK_EXECUTION_TIMEOUT,
+        TonyConfigurationKeys.DEFAULT_TASK_EXECUTION_TIMEOUT);
     hbInterval = tonyConf.getInt(TonyConfigurationKeys.TASK_HEARTBEAT_INTERVAL_MS,
         TonyConfigurationKeys.DEFAULT_TASK_HEARTBEAT_INTERVAL_MS);
     String[] shellEnvs = tonyConf.getStrings(TonyConfigurationKeys.EXECUTION_ENV);

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -167,6 +167,9 @@ public class TonyConfigurationKeys {
   public static final String TASK_GPU_METRICS_ENABLED = TONY_TASK_PREFIX + "gpu-metrics.enabled";
   public static final boolean DEFAULT_TASK_GPU_METRICS_ENABLED = true;
 
+  public static final String TASK_EXECUTION_TIMEOUT = TONY_TASK_PREFIX + "executor.execution-timeout-ms";
+  public static final int DEFAULT_TASK_EXECUTION_TIMEOUT = 0;
+
   // AM configurations
   public static final String AM_PREFIX = TONY_PREFIX + "am.";
 
@@ -262,11 +265,6 @@ public class TonyConfigurationKeys {
   public static final int DEFAULT_CONTAINER_REGISTRATION_TIMEOUT = 15 * 60 * 1000;
   public static final String CONTAINER_ALLOCATION_TIMEOUT = CONTAINER_PREFIX + "allocation.timeout";
   public static final int DEFAULT_CONTAINER_ALLOCATION_TIMEOUT = 0;
-
-  // Worker configurations
-  public static final String WORKER_PREFIX = TONY_PREFIX + "worker.";
-  public static final String WORKER_TIMEOUT = WORKER_PREFIX + "timeout";
-  public static final int DEFAULT_WORKER_TIMEOUT = 0;
 
   // Job types that we don't wait to finish
   public static final String UNTRACKED_JOBTYPES = TONY_APPLICATION_PREFIX + "untracked.jobtypes";

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -125,6 +125,12 @@
     <value>true</value>
   </property>
 
+  <property>
+    <description>Timeout, in milliseconds for the user's python processes before forcibly killing them.</description>
+    <name>tony.task.executor.execution-timeout-ms</name>
+    <value>0</value>
+  </property>
+
   <!-- AM configurations -->
   <property>
     <description>How many times a failed AM should retry.</description>
@@ -180,13 +186,6 @@
     <description>Timeout, in milliseconds for allocated container registration before forcibly killing application.</description>
     <name>tony.container.registration.timeout</name>
     <value>-1</value>
-  </property>
-
-  <!-- Worker configurations -->
-  <property>
-    <description>Timeout, in milliseconds for the user's python processes before forcibly killing them.</description>
-    <name>tony.worker.timeout</name>
-    <value>0</value>
   </property>
 
   <property>


### PR DESCRIPTION
`tony.worker.timeout` is specified for shell execution timeout, but it's name cause misleading. So rename to `tony.task.executor.execution-timeout-ms`