### PR TITLE
TonyClient to create FileSystem from Path to support fully qualified HDFS path

### DIFF
--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -57,7 +57,7 @@ public class ClusterSubmitter extends TonySubmitter {
     Path cachedLibPath = null;
     try (FileSystem fs = FileSystem.get(hdfsConf)) {
       cachedLibPath = new Path(fs.getHomeDirectory(), TONY_FOLDER + Path.SEPARATOR + UUID.randomUUID().toString());
-      Utils.uploadFileAndSetConfResources(cachedLibPath, new Path(jarLocation), TONY_JAR_NAME, client.getTonyConf(), fs,
+      Utils.uploadFileAndSetConfResources(cachedLibPath, new Path(jarLocation), TONY_JAR_NAME, client.getTonyConf(),
           LocalResourceType.FILE, TonyConfigurationKeys.getContainerResourcesKey());
       LOG.info("Copying " + jarLocation + " to: " + cachedLibPath);
       boolean sanityCheck = client.init(args);

--- a/tony-core/src/main/java/com/linkedin/tony/LocalizableResource.java
+++ b/tony-core/src/main/java/com/linkedin/tony/LocalizableResource.java
@@ -5,6 +5,7 @@
 package com.linkedin.tony;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -67,12 +68,12 @@ public class LocalizableResource {
     return localizedFileName;
   }
 
-  public LocalizableResource(String completeResourceString, FileSystem fs) throws ParseException, IOException  {
+  public LocalizableResource(String completeResourceString, Configuration conf) throws ParseException, IOException  {
     this.completeResourceString = completeResourceString;
-    this.parse(fs);
+    this.parse(conf);
   }
 
-  private void parse(FileSystem fs) throws ParseException, IOException {
+  private void parse(Configuration conf) throws ParseException, IOException {
     String filePath = completeResourceString;
     resourceType = LocalResourceType.FILE;
     if (completeResourceString.toLowerCase().endsWith(Constants.ARCHIVE_SUFFIX)) {
@@ -85,6 +86,7 @@ public class LocalizableResource {
         throw new ParseException("Failed to parse file: " + completeResourceString);
     }
     sourceFilePath = new Path(tuple[0]);
+    FileSystem fs = sourceFilePath.getFileSystem(conf);
     if (isLocalFile()) {
       FileSystem localFs = FileSystem.getLocal(fs.getConf());
       sourceFileStatus = localFs.getFileStatus(sourceFilePath);

--- a/tony-core/src/main/java/com/linkedin/tony/TaskScheduler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskScheduler.java
@@ -106,11 +106,11 @@ public class TaskScheduler {
   private Map<String, LocalResource> getContainerResources(String jobName) {
     Map<String, LocalResource> containerResources = new ConcurrentHashMap<>(localResources);
     String[] resources = tonyConf.getStrings(TonyConfigurationKeys.getResourcesKey(jobName));
-    Utils.addResources(resources, containerResources, resourceFs);
+    Utils.addResources(resources, containerResources, tonyConf);
 
     // All resources available to all containers
     resources = tonyConf.getStrings(TonyConfigurationKeys.getContainerResourcesKey());
-    Utils.addResources(resources, containerResources, resourceFs);
+    Utils.addResources(resources, containerResources, tonyConf);
     return containerResources;
   }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonySession.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonySession.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
@@ -121,8 +120,7 @@ public class TonySession {
 
     try {
       if (hdfsClasspathDir != null) {
-        FileSystem fs = FileSystem.get(new URI(hdfsClasspathDir), hdfsConf);
-        Utils.addResource(hdfsClasspathDir, localResources, fs);
+        Utils.addResource(hdfsClasspathDir, localResources, hdfsConf);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/tony-core/src/test/java/com/linkedin/tony/TestLocalizableResource.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestLocalizableResource.java
@@ -6,7 +6,6 @@ package com.linkedin.tony;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -16,21 +15,21 @@ import java.io.IOException;
 public class TestLocalizableResource {
   @Test
   public void testLocalResourceParsing() throws IOException, ParseException {
-    FileSystem fs = FileSystem.get(new Configuration());
-    LocalizableResource resource = new LocalizableResource("tony-core/src/test/resources/test.zip", fs);
+    Configuration conf = new Configuration();
+    LocalizableResource resource = new LocalizableResource("tony-core/src/test/resources/test.zip", conf);
     Assert.assertNotNull(resource.toLocalResource().getResource());
     Assert.assertEquals(resource.getLocalizedFileName(), "test.zip");
 
-    LocalizableResource resource2 = new LocalizableResource("tony-core/src/test/resources/test.zip::ok.123", fs);
+    LocalizableResource resource2 = new LocalizableResource("tony-core/src/test/resources/test.zip::ok.123", conf);
     Assert.assertNotNull(resource2.toLocalResource().getResource());
     Assert.assertEquals(resource2.getLocalizedFileName(), "ok.123");
 
-    LocalizableResource resource3 = new LocalizableResource("tony-core/src/test/resources/test.zip::ok#archive", fs);
+    LocalizableResource resource3 = new LocalizableResource("tony-core/src/test/resources/test.zip::ok#archive", conf);
     Assert.assertNotNull(resource3.toLocalResource().getResource());
     Assert.assertSame(resource3.toLocalResource().getType(), LocalResourceType.ARCHIVE);
     Assert.assertEquals(resource3.getLocalizedFileName(), "ok");
 
-    LocalizableResource resource4 = new LocalizableResource("tony-core/src/test/resources/test.zip#archive", fs);
+    LocalizableResource resource4 = new LocalizableResource("tony-core/src/test/resources/test.zip#archive", conf);
     Assert.assertNotNull(resource4.toLocalResource().getResource());
     Assert.assertSame(resource4.toLocalResource().getType(), LocalResourceType.ARCHIVE);
     Assert.assertEquals(resource4.getLocalizedFileName(), "test.zip");


### PR DESCRIPTION
FileSystem.get() will only use default base URI for path. However when using fully qualified HDFS path, the base URI can be different from default.
This change part of the TonyClient to use path.getFileSystem() to get the path to handle fully qualified HDFS path.

See APA-50360 for details.