### PR TITLE
Introduce some job stop policies on TFRuntime

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -334,4 +334,14 @@ public class TonyConfigurationKeys {
 
   public static final String TB_GPUS = TB_JOB_PREFIX + "gpus";
   public static final int DEFAULT_TB_GPUS = 0;
+
+  public static final String TASK_RUN_ALONE_TIMEOUT = TONY_APPLICATION_PREFIX + "([a-z]+)\\.run-alone.timeout";
+  public static final int DEFAULT_TASK_RUN_ALONE_TIMEOUT = 0;
+
+  public static String getTaskRunAloneTimeoutKey(String type) {
+    return String.format(TONY_APPLICATION_PREFIX +  "%s.run-alone.timeout", type);
+  }
+
+  public static final String TASK_SUCCEEDED_ON_RUN_ALONE_TIMEOUT_JOBTYPES =
+          TONY_APPLICATION_PREFIX + "succeeded-on-run-alone-timeout.jobtypes";
 }

--- a/tony-core/src/main/java/com/linkedin/tony/TonySession.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonySession.java
@@ -192,6 +192,13 @@ public class TonySession {
         .flatMap(entry -> Arrays.stream(entry.getValue())).filter(task -> task != null && task.isCompleted()).count();
   }
 
+  public int getNotCompletedTrackedTasks(String jobType) {
+    return (int) jobTasks.entrySet().stream().filter(entry -> Utils.isJobTypeMonitored(entry.getKey(), tonyConf))
+            .filter(entry -> entry.getKey().equals(jobType))
+            .flatMap(entry -> Arrays.stream(entry.getValue()))
+            .filter(task -> task == null || !task.isCompleted()).count();
+  }
+
   public int getNumFailedTasks() {
     return (int) jobTasks.values().stream().flatMap(arr -> Arrays.stream(arr)).filter(task -> task != null && task.isFailed()).count();
   }

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -459,6 +459,27 @@ public class Utils {
         .sum();
   }
 
+  public static Map<String, Long> getRunAloneJobTypesWithTimeout(Configuration conf) {
+    return conf.getValByRegex(TonyConfigurationKeys.TASK_RUN_ALONE_TIMEOUT)
+        .keySet().stream().map(Utils::getRunAloneTaskTypes)
+        .collect(Collectors.toMap(type -> type, type -> conf.getLong(TonyConfigurationKeys.getTaskRunAloneTimeoutKey(type), 0)));
+  }
+
+  public static Set<String> getSucceededOnRunAloneJobTimeout(Configuration conf) {
+    return Arrays.stream(conf.getStrings(TonyConfigurationKeys.TASK_SUCCEEDED_ON_RUN_ALONE_TIMEOUT_JOBTYPES))
+        .collect(Collectors.toSet());
+  }
+
+  private static String getRunAloneTaskTypes(String confKey) {
+    Pattern instancePattern = Pattern.compile(TonyConfigurationKeys.TASK_RUN_ALONE_TIMEOUT);
+    Matcher instanceMatcher = instancePattern.matcher(confKey);
+    if (instanceMatcher.matches()) {
+      return instanceMatcher.group(1);
+    } else {
+      return null;
+    }
+  }
+
   /**
    * Extracts TensorFlow job name from configuration key of the form "tony.*.instances".
    * @param confKey Name of the configuration key


### PR DESCRIPTION
### Why
On TFRuntime, I found two problems on tensorflow training on our production env.
1. Sometimes, when using tf estimator api, evaluator maybe wait the newest global step but chief has finished. So evaluator will hang.
2. Sometimes, worker will hang due to tf bugs, but chief has finished its task. So we need to kill workers which not finished.

> Besides do we need to make job failed when some worker or evaluator not finished? 

I think it can depends on user with config.


### How 
To fix the above problems, introduce two conf key
1. `tony.application.xxxx.run-alone.timeout` 
(like `tony.application.xxxx.run-alone.timeout=3600000`)

2. `tony.application.succeeded-on-run-alone-timeout.jobtypes` 
(like `tony.application.succeeded-on-run-alone-timeout.jobtypes=evaluator,worker`)