### PR TITLE
Make job fail when partial tasks' pre-dependent tasks finished and exceeds the waiting timeout

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -337,10 +337,9 @@ public class TonyConfigurationKeys {
 
   /**
    * Introduce the group dependency waiting time(sec), like as follows:
-   * tony.application.group.a = worker,chief
-   * tony.application.group.b = evaluator
+   * tony.application.group.A = worker,chief
    *
-   * tony.application.dependency.b.timeout.after.a = 3600
+   * tony.application.dependency.evaluator.timeout.after.A = 3600
    */
   public static final String GROUP_REGEX = TONY_APPLICATION_PREFIX + "group\\.([A-Za-z]+)$";
   public static final String GROUP_DEPEND_TIMEOUT_REGEX =

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -334,4 +334,23 @@ public class TonyConfigurationKeys {
 
   public static final String TB_GPUS = TB_JOB_PREFIX + "gpus";
   public static final int DEFAULT_TB_GPUS = 0;
+
+  /**
+   * Introduce the group dependency waiting time(sec), like as follows:
+   * tony.application.group.a = worker,chief
+   * tony.application.group.b = evaluator
+   *
+   * tony.application.dependency.b.timeout.after.a = 3600
+   */
+  public static final String GROUP_REGEX = TONY_APPLICATION_PREFIX + "group\\.([A-Za-z]+)$";
+  public static final String GROUP_DEPEND_TIMEOUT_REGEX =
+      TONY_APPLICATION_PREFIX + "dependency\\.([A-Za-z]+)\\.timeout\\.after\\.([A-Za-z]+)$";
+
+  public static String getGroupKey(String groupName) {
+    return String.format(TONY_APPLICATION_PREFIX + "group.%s", groupName);
+  }
+
+  public static String getGroupDependentKey(String grp, String dependentGrp) {
+    return String.format(TONY_APPLICATION_PREFIX + "dependency.%s.timeout.after.%s", grp, dependentGrp);
+  }
 }

--- a/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
+++ b/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
@@ -16,13 +16,17 @@
 package com.linkedin.tony.runtime;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 
@@ -33,6 +37,7 @@ import com.linkedin.tony.Framework;
 import com.linkedin.tony.TaskExecutor;
 import com.linkedin.tony.TonyConfigurationKeys;
 import com.linkedin.tony.TonySession;
+import com.linkedin.tony.util.Utils;
 
 import static com.linkedin.tony.Constants.SIDECAR_TB_ROLE_NAME;
 
@@ -54,6 +59,12 @@ public abstract class MLGenericRuntime extends AbstractFrameworkRuntime {
         private List<String> illegalConfKeyRegexs;
         private long lastRegisterWorkerTime = System.currentTimeMillis();
         private long runtimeInitialTime = System.currentTimeMillis();
+
+        // Group dependencies policy.
+        Map<String, List<String>> groupMembers;
+        Map<String, List<String>> memberInGroups;
+        // todo: Need to support single group dependent multiple other groups
+        Map<String, Pair<String, Long>> groupDependencies;
 
         @Override
         public String constructClusterSpec(String taskId) throws IOException {
@@ -120,7 +131,109 @@ public abstract class MLGenericRuntime extends AbstractFrameworkRuntime {
                 session.setFinalStatus(FinalApplicationStatus.FAILED, "Container allocation timeout.");
                 return false;
             }
+
+            /**
+             * Checking the task roles completion timeout when its' pre-dependency tasks finished
+             *
+             * For example, tensorflow estimator training job will include some roles of ps/worker/evaluator/chief.
+             * Actually, due to the bug of tensorflow or misusing the estimator api, sometimes evaluator will hang.
+             * So if we use the configuration as follows, when evaluator is still running after timeout and
+             * chief/workers are finished, the mechanism of dependency group timeout will make job failed.
+             *
+             * dependency group timeout configuration as follows:
+             *
+             * tony.application.group.A = worker,chief
+             * tony.application.group.B = evaluator
+             * tony.application.dependency.B.after.timeout.A = 3600
+             */
+            String errorMsg = groupDependencyTimeout(tonyConf);
+            if (errorMsg != null) {
+                session.setFinalStatus(FinalApplicationStatus.FAILED, errorMsg);
+                return false;
+            }
             return true;
+        }
+
+        @VisibleForTesting
+        protected String groupDependencyTimeout(Configuration tonyConf) {
+            if (groupDependencies == null) {
+                groupDependencies = Utils.getGroupDependencies(tonyConf);
+            }
+
+            if (groupDependencies == null || groupDependencies.isEmpty()) {
+                return null;
+            }
+
+            if (groupMembers == null) {
+                groupMembers = Utils.getAllGroupJobTypes(tonyConf);
+            }
+
+            if (memberInGroups == null) {
+                memberInGroups = getMemberInGroups(groupMembers);
+            }
+
+
+            Map<String, TonySession.TonyTask[]> allTasks = session.getTonyTasks();
+            List<TonySession.TonyTask> runningTasks = session.getRunningTasks();
+
+            // Get the running jobs' type, like the tf roles of ps/worker/chief/evaluator
+            Set<String> runningJobTypes = runningTasks.stream()
+                    .map(TonySession.TonyTask::getJobName)
+                    .filter(jobname -> memberInGroups.containsKey(jobname))
+                    .collect(Collectors.toSet());
+
+            for (String runningTaskType : runningJobTypes) {
+                for (String group : memberInGroups.get(runningTaskType)) {
+                    if (!groupDependencies.containsKey(group)) {
+                        continue;
+                    }
+
+                    Pair<String, Long> dependentGroupPair = groupDependencies.get(group);
+                    String dependentGroupName = dependentGroupPair.getKey();
+                    long timeout = dependentGroupPair.getValue() * 1000;
+
+                    if (!groupMembers.containsKey(dependentGroupName)) {
+                        continue;
+                    }
+
+                    for (String dependentsGroupJobtype : groupMembers.get(dependentGroupName)) {
+                        if (Utils.existRunningTasksWithJobtype(runningTasks, dependentsGroupJobtype)) {
+                            continue;
+                        }
+                        // Find out the latest finished task in this task type, if the specified timeout exceed,
+                        // make the job fail.
+                        long latestFinishedTime =
+                                Arrays.stream(allTasks.get(dependentsGroupJobtype))
+                                        .mapToLong(x -> x.getEndTime() == 0L ? System.currentTimeMillis() : x.getEndTime())
+                                        .max().getAsLong();
+
+                        if (System.currentTimeMillis() - latestFinishedTime > timeout) {
+                            return String.format("Jobtype: %s in group: %s runs exceeded timeout due it's "
+                                            + "dependent jobtype: %s in group: %s has been finished.",
+                                    runningTaskType, group, dependentsGroupJobtype, dependentGroupName);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private Map<String, List<String>> getMemberInGroups(Map<String, List<String>> groupMembers) {
+            /**
+             * key: job type name
+             * value: the list of groups
+             */
+            Map<String, List<String>> memberInGroups = new HashMap<>();
+            for (Map.Entry<String, List<String>> entry : groupMembers.entrySet()) {
+                String group = entry.getKey();
+                List<String> members = entry.getValue();
+                for (String member : members) {
+                    memberInGroups.putIfAbsent(member, new ArrayList<>());
+                    memberInGroups.get(member).add(group);
+                }
+            }
+            return memberInGroups;
         }
 
         private boolean containerAllocationTimeout(Configuration tonyConf) {

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -462,11 +462,11 @@ public class Utils {
         .sum();
   }
 
-  public static Map<String, Pair<String, Long>> getGroupDependencies(Configuration tonyConf) {
+  public static Map<String, Pair<String, Long>> getJobTypeDependentGrps(Configuration tonyConf) {
     return tonyConf.getValByRegex(TonyConfigurationKeys.GROUP_DEPEND_TIMEOUT_REGEX).keySet().stream()
             .map(Utils::getDependentGrps)
             .map(pair -> Utils.getDependentTimeout(tonyConf, pair))
-            .collect(Collectors.toMap(Triple::getLeft, x -> Pair.of(x.getMiddle(), x.getRight())));
+            .collect(Collectors.toMap(Triple::getLeft, x -> Pair.of(x.getMiddle(), x.getRight()), (oldV, newV) -> newV));
   }
 
   private static Triple<String, String, Long> getDependentTimeout(Configuration tonyConf, Pair<String, String> pair) {

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -38,6 +38,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -68,6 +70,7 @@ import com.linkedin.tony.HadoopCompatibleAdapter;
 import com.linkedin.tony.LocalizableResource;
 import com.linkedin.tony.TonyConfig;
 import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.TonySession;
 import com.linkedin.tony.horovod.HorovodClusterSpec;
 import com.linkedin.tony.rpc.TaskInfo;
 import com.linkedin.tony.models.JobContainerRequest;
@@ -459,19 +462,66 @@ public class Utils {
         .sum();
   }
 
+  public static Map<String, Pair<String, Long>> getGroupDependencies(Configuration tonyConf) {
+    return tonyConf.getValByRegex(TonyConfigurationKeys.GROUP_DEPEND_TIMEOUT_REGEX).keySet().stream()
+            .map(Utils::getDependentGrps)
+            .map(pair -> Utils.getDependentTimeout(tonyConf, pair))
+            .collect(Collectors.toMap(Triple::getLeft, x -> Pair.of(x.getMiddle(), x.getRight())));
+  }
+
+  private static Triple<String, String, Long> getDependentTimeout(Configuration tonyConf, Pair<String, String> pair) {
+    String grp = pair.getKey();
+    String dependentGrp = pair.getValue();
+    long timeout = tonyConf.getLong(TonyConfigurationKeys.getGroupDependentKey(grp, dependentGrp), 0L);
+    return Triple.of(grp, dependentGrp, timeout);
+  }
+
+  private static Pair<String, String> getDependentGrps(String confKey) {
+    Pattern instancePattern = Pattern.compile(TonyConfigurationKeys.GROUP_DEPEND_TIMEOUT_REGEX);
+    Matcher instanceMatcher = instancePattern.matcher(confKey);
+    if (instanceMatcher.matches()) {
+      return Pair.of(instanceMatcher.group(1), instanceMatcher.group(2));
+    }
+    return null;
+  }
+
+  public static Map<String, List<String>> getAllGroupJobTypes(Configuration conf) {
+    return conf.getValByRegex(TonyConfigurationKeys.GROUP_REGEX).keySet().stream()
+        .map(Utils::getGroupName)
+        .map(groupName -> Utils.getGroupMembers(conf, groupName))
+        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+  }
+
+  private static Pair<String, List<String>> getGroupMembers(Configuration conf, String groupName) {
+    return Pair.of(groupName, Arrays.asList(conf.getStrings(TonyConfigurationKeys.getGroupKey(groupName))));
+  }
+
+  /**
+   * Extracts group name from configuration key of the form "tony.application.group.*".
+   * @param confKey Name of the configuration key
+   * @return group name
+   */
+  private static String getGroupName(String confKey) {
+    return getRegexKey(confKey, TonyConfigurationKeys.GROUP_REGEX);
+  }
+
+  private static String getRegexKey(String conf, String regex) {
+    Pattern instancePattern = Pattern.compile(regex);
+    Matcher instanceMatcher = instancePattern.matcher(conf);
+    if (instanceMatcher.matches()) {
+      return instanceMatcher.group(1);
+    } else {
+      return null;
+    }
+  }
+
   /**
    * Extracts TensorFlow job name from configuration key of the form "tony.*.instances".
    * @param confKey Name of the configuration key
    * @return TensorFlow job name
    */
   public static String getTaskType(String confKey) {
-    Pattern instancePattern = Pattern.compile(TonyConfigurationKeys.INSTANCES_REGEX);
-    Matcher instanceMatcher = instancePattern.matcher(confKey);
-    if (instanceMatcher.matches()) {
-      return instanceMatcher.group(1);
-    } else {
-      return null;
-    }
+    return getRegexKey(confKey, TonyConfigurationKeys.INSTANCES_REGEX);
   }
 
   public static boolean isArchive(String path) {
@@ -794,6 +844,10 @@ public class Utils {
     HorovodClusterSpec spec =
             objectMapper.readValue(clusterSpec, new TypeReference<HorovodClusterSpec>() { });
     return spec;
+  }
+
+  public static boolean existRunningTasksWithJobtype(List<TonySession.TonyTask> runningTasks, String jobtype) {
+    return runningTasks.stream().anyMatch(x -> x.getJobName().equals(jobtype));
   }
 
   private Utils() { }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -628,6 +628,32 @@ public class TestTonyE2E  {
   }
 
   /**
+   * When chief finished, the worker will finished after 10s
+   */
+  @Test
+  public void testGroupDependencyTimeoutShouldPass() throws ParseException, IOException {
+    client.init(new String[]{
+            "--src_dir", "tony-core/src/test/resources/scripts",
+            "--hdfs_classpath", libPath,
+            "--container_env", Constants.SKIP_HADOOP_PATH + "=true",
+            "--python_venv", "tony-core/src/test/resources/test.zip",
+            "--executes", "python exit_0.py",
+            "--conf", "tony.chief.instances=1",
+            "--conf", "tony.worker.instances=2",
+            "--conf", "tony.worker.command=python forever_not_exit.py",
+            "--conf", "tony.application.framework=tensorflow",
+            "--container_env", Constants.SIDECAR_TB_TEST_KEY + "=true",
+            "--conf", "tony.application.group.A=chief",
+            "--conf", "tony.application.group.B=worker",
+            "--conf", "tony.application.dependency.B.timeout.after.A=10",
+    });
+    client.addListener(handler);
+    int exitCode = client.start();
+    Assert.assertEquals(exitCode, -1);
+    client.removeListener(handler);
+  }
+
+  /**
    * Since we are switching from passing arguments to ApplicationMaster & TaskExecutor
    * to passing tony configuration file. It is critical to make sure all fields in
    * TonyConfFinal.xml is properly set up.

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -642,10 +642,8 @@ public class TestTonyE2E  {
             "--conf", "tony.worker.instances=2",
             "--conf", "tony.worker.command=python forever_not_exit.py",
             "--conf", "tony.application.framework=tensorflow",
-            "--container_env", Constants.SIDECAR_TB_TEST_KEY + "=true",
             "--conf", "tony.application.group.A=chief",
-            "--conf", "tony.application.group.B=worker",
-            "--conf", "tony.application.dependency.B.timeout.after.A=10",
+            "--conf", "tony.application.dependency.worker.timeout.after.A=10",
     });
     client.addListener(handler);
     int exitCode = client.start();

--- a/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
+++ b/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
@@ -16,12 +16,15 @@
 package com.linkedin.tony.runtime;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.linkedin.tony.Constants;
 import com.linkedin.tony.Framework;
 import com.linkedin.tony.TaskExecutor;
+import com.linkedin.tony.TonySession;
 
 import static com.linkedin.tony.TonyConfigurationKeys.TENSORBOARD_LOG_DIR;
 
@@ -32,6 +35,11 @@ public class TestMLGenericRuntime {
         @Override
         public Framework.TaskExecutorAdapter getTaskAdapter(TaskExecutor taskExecutor) {
             return new TestTaskExecutorAdapter(taskExecutor);
+        }
+
+        @Override
+        public Framework.ApplicationMasterAdapter getAMAdapter() {
+            return new AM();
         }
 
         @Override
@@ -79,5 +87,149 @@ public class TestMLGenericRuntime {
 
         taskExecutor.setJobName("tensorboard");
         Assert.assertTrue(taskExecutorAdapter.needReserveTBPort());
+    }
+
+    /**
+     * When no specifing dependencies, it will always return null.
+     */
+    @Test
+    public void testGroupDependencyNoConfShouldPass() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.dependency.A.timeout.after.B", "3600");
+        conf.set("tony.application.dependency.B.timeout.after.C", "3600");
+
+        TonySession session = buildMockSession(conf);
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertNull(
+                am.groupDependencyTimeout(conf)
+        );
+    }
+
+    @Test
+    public void testGroupDependencyShouldPass() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.group.A", "worker,chief");
+        conf.set("tony.application.group.B", "evaluator");
+        conf.set("tony.application.dependency.B.timeout.after.A", "3600");
+
+        TonySession session = buildMockSession(conf);
+        TonySession.TonyTask chiefTask = session.getTask("chief", "0");
+        chiefTask.setEndTime(System.currentTimeMillis() - 1000 * 60 * 120);
+
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertEquals(
+                am.groupDependencyTimeout(conf),
+                "Jobtype: evaluator in group: B runs exceeded timeout due it's dependent "
+                        + "jobtype: chief in group: A has been finished."
+        );
+    }
+
+    @Test
+    public void testGroupDependencyWorkerWhenChiefFinished() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.group.A", "chief");
+        conf.set("tony.application.group.B", "otherWorker");
+        conf.set("tony.application.dependency.B.timeout.after.A", "3600");
+
+        TonySession session = buildMockSession(conf);
+        TonySession.TonyTask chiefTask = session.getTask("chief", "0");
+        chiefTask.setEndTime(System.currentTimeMillis() - 1000 * 60 * 120);
+
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertEquals(
+                am.groupDependencyTimeout(conf),
+                "Jobtype: otherWorker in group: B runs exceeded timeout due it's dependent jobtype: chief in group: A has been finished."
+        );
+    }
+
+    @Test
+    public void testGroupDependencyWithMultipleGroup() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.group.A", "chief");
+        conf.set("tony.application.group.B", "otherWorker");
+        conf.set("tony.application.dependency.B.timeout.after.A", String.valueOf(60 * 240));
+
+        conf.set("tony.application.group.C", "chief");
+        conf.set("tony.application.group.D", "otherWorker");
+        conf.set("tony.application.dependency.D.timeout.after.C", "3600");
+
+        TonySession session = buildMockSession(conf);
+        TonySession.TonyTask chiefTask = session.getTask("chief", "0");
+        chiefTask.setEndTime(System.currentTimeMillis() - 1000 * 60 * 120);
+
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertEquals(
+                am.groupDependencyTimeout(conf),
+                "Jobtype: otherWorker in group: D runs exceeded timeout due it's dependent jobtype: chief in group: C has been finished."
+        );
+    }
+
+    @Test
+    public void testGroupDependencyWithoutTimeoutMultipleGroup() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.group.A", "chief");
+        conf.set("tony.application.group.B", "otherWorker");
+        conf.set("tony.application.dependency.B.timeout.after.A", String.valueOf(60 * 240));
+
+        TonySession session = buildMockSession(conf);
+        TonySession.TonyTask chiefTask = session.getTask("chief", "0");
+        chiefTask.setEndTime(System.currentTimeMillis() - 1000 * 60 * 120);
+
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertNull(
+                am.groupDependencyTimeout(conf)
+        );
+    }
+
+    private TonySession buildMockSession(Configuration tonyConf) {
+        TonySession session = new TonySession.Builder().setTonyConf(tonyConf).build();
+
+        TonySession.TonyTask ps0 = session.buildTonyTask(Constants.PS_JOB_NAME, "0", "localhost");
+        TonySession.TonyTask ps1 = session.buildTonyTask(Constants.PS_JOB_NAME, "1", "localhost");
+
+        TonySession.TonyTask chief = session.buildTonyTask(Constants.CHIEF_JOB_NAME, "0", "localhost");
+
+        TonySession.TonyTask worker0 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "0", "localhost");
+        TonySession.TonyTask worker1 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "1", "localhost");
+        TonySession.TonyTask worker2 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "2", "localhost");
+
+        TonySession.TonyTask otherWorker0 = session.buildTonyTask("otherWorker", "0", "localhost");
+
+        TonySession.TonyTask evaluator0 = session.buildTonyTask(Constants.EVALUATOR_JOB_NAME, "0", "localhost");
+
+        ps0.setTaskInfo();
+        ps1.setTaskInfo();
+        chief.setTaskInfo();
+        worker0.setTaskInfo();
+        worker1.setTaskInfo();
+        worker2.setTaskInfo();
+        evaluator0.setTaskInfo();
+        otherWorker0.setTaskInfo();
+
+        session.addTask(ps0);
+        session.addTask(ps1);
+        session.addTask(chief);
+        session.addTask(worker0);
+        session.addTask(worker1);
+        session.addTask(worker2);
+        session.addTask(evaluator0);
+        session.addTask(otherWorker0);
+
+        chief.setExitStatus(ContainerExitStatus.SUCCESS);
+        worker0.setExitStatus(ContainerExitStatus.SUCCESS);
+        worker1.setExitStatus(ContainerExitStatus.SUCCESS);
+        worker2.setExitStatus(ContainerExitStatus.SUCCESS);
+
+        return session;
     }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
+++ b/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
@@ -16,7 +16,6 @@
 package com.linkedin.tony.runtime;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.yarn.api.records.CollectorInfo;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
@@ -344,7 +344,7 @@ public class TestUtils {
     conf.set("tony.application.dependency.A.timeout.after.B", "3600");
     conf.set("tony.application.dependency.B.timeout.after.C", "3600");
 
-    Map<String, Pair<String, Long>> dependenciesIndex = Utils.getGroupDependencies(conf);
+    Map<String, Pair<String, Long>> dependenciesIndex = Utils.getJobTypeDependentGrps(conf);
     assertTrue(dependenciesIndex.containsKey("A"));
     assertTrue(dependenciesIndex.containsKey("B"));
     assertEquals(dependenciesIndex.get("A").getKey(), "B");

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
@@ -19,9 +19,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -319,5 +321,35 @@ public class TestUtils {
     assertEquals(linksToBeDisplayed.size(), 2);
     assertEquals(linksToBeDisplayed.get("Logs"), "/" + LOGS_SUFFIX + "/" + "fakeJobId");
     assertEquals(linksToBeDisplayed.get("Events"), "/" + JOBS_SUFFIX + "/" + "fakeJobId");
+  }
+
+  @Test
+  public void testGetAllGroupJobTypes() {
+    Configuration conf = new Configuration();
+    conf.addResource("tony-default.xml");
+    conf.set("tony.application.group.A", "worker,chief");
+    conf.set("tony.application.group.B", "evaluator");
+
+    Map<String, List<String>> groupIndex = Utils.getAllGroupJobTypes(conf);
+    assertTrue(groupIndex.containsKey("A"));
+    assertTrue(groupIndex.containsKey("B"));
+    assertEquals(groupIndex.get("A"), Arrays.asList("worker", "chief"));
+    assertEquals(groupIndex.get("B"), Arrays.asList("evaluator"));
+  }
+
+  @Test
+  public void testGetGroupDependencies() {
+    Configuration conf = new Configuration();
+    conf.addResource("tony-default.xml");
+    conf.set("tony.application.dependency.A.timeout.after.B", "3600");
+    conf.set("tony.application.dependency.B.timeout.after.C", "3600");
+
+    Map<String, Pair<String, Long>> dependenciesIndex = Utils.getGroupDependencies(conf);
+    assertTrue(dependenciesIndex.containsKey("A"));
+    assertTrue(dependenciesIndex.containsKey("B"));
+    assertEquals(dependenciesIndex.get("A").getKey(), "B");
+    assertEquals(dependenciesIndex.get("A").getValue(), Long.valueOf("3600"));
+    assertEquals(dependenciesIndex.get("B").getKey(), "C");
+    assertEquals(dependenciesIndex.get("B").getValue(), Long.valueOf("3600"));
   }
 }

--- a/tony-core/src/test/resources/scripts/forever_not_exit.py
+++ b/tony-core/src/test/resources/scripts/forever_not_exit.py
@@ -1,0 +1,8 @@
+#
+# Copyright 2021 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+# See LICENSE in the project root for license information.
+#
+import time
+
+while True:
+    time.sleep(1)


### PR DESCRIPTION
This PR is to solve the problems of tf workers hang when chief has been finished and other bugs.

For example, tensorflow estimator training job will include some roles of ps/worker/evaluator/chief. Actually, due to the bug of tensorflow or misusing the estimator api, sometimes evaluator will hang. So if we use the configuration as follows, when evaluator is still running after timeout and chief and workers are all finished, the mechanism of dependency group timeout will make job failed.

Conf as follows, the evaluator will be alive 3600(sec) after workers and chief are all finished.
```
tony.application.group.A = worker,chief
tony.application.dependency.evaluator.timeout.after.A = 3600
```

So, this PR introduce the conf of `tony.application.group.{GROUP_NAME}={JOB_TYPES}` and `tony.application.dependency.{JOB_TYPE}.timeout.after.{GROUP_NAME} = 3600`


Besides, due to tensorflow bug, sometimes the workers will hang after the chief finished. We could use above conf to solve it.  The worker will be alive 3600(sec) after chief finished.
```
tony.application.group.A = chief
tony.application.dependency.worker.timeout.after.A = 3600
```




