### PR TITLE
Make dependency-group-timeout check ignored until all tasks scheduled

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
+++ b/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
@@ -156,9 +156,15 @@ public abstract class MLGenericRuntime extends AbstractFrameworkRuntime {
 
         @VisibleForTesting
         protected String groupDependencyTimeout(Configuration tonyConf) {
+            /**
+             * precheck:
+             * Is group dependency checking timeout enabled?
+             * If not, directly return null.
+             */
             if (taskWithDependentGrpsIndex == null) {
                 taskWithDependentGrpsIndex = Utils.getJobTypeDependentGrps(tonyConf);
             }
+
             // groupDependencies is map, key: waiting role, value: pre-dependent groups and waiting timeout
             if (taskWithDependentGrpsIndex == null || taskWithDependentGrpsIndex.isEmpty()) {
                 return null;
@@ -167,6 +173,15 @@ public abstract class MLGenericRuntime extends AbstractFrameworkRuntime {
             // groupMembers is map, key: groupName, value: its members in this group
             if (grpWithMembersIndex == null) {
                 grpWithMembersIndex = Utils.getAllGroupJobTypes(tonyConf);
+            }
+
+            if (grpWithMembersIndex == null || grpWithMembersIndex.isEmpty()) {
+                return null;
+            }
+
+            if (!session.allTasksScheduled()) {
+                log.info("Group dependency timeout check will be ignored until all tasks scheduled.");
+                return null;
             }
 
             // memberInGroups is map. key: jobtype name, value: in which groups

--- a/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
+++ b/tony-core/src/test/java/com/linkedin/tony/runtime/TestMLGenericRuntime.java
@@ -213,6 +213,46 @@ public class TestMLGenericRuntime {
         );
     }
 
+    /**
+     * Test case for partial tasks scheduled, but others are not.
+     * DependentGroup timeout should pass.
+     */
+    @Test
+    public void testPartialTaskScheduledShouldPass() {
+        Configuration conf = new Configuration();
+        conf.addResource("tony-default.xml");
+        conf.set("tony.application.group.A", "chief");
+        conf.set("tony.application.dependency.worker.timeout.after.A", String.valueOf(60 * 240));
+        conf.set("tony.chief.instances", "1");
+        conf.set("tony.worker.instances", "4");
+        conf.set("tony.ps.instances", "2");
+
+        TonySession session = buildPartialTaskScheduledSession(conf);
+        MLGenericRuntime.AM am = (MLGenericRuntime.AM) runtime.getAMAdapter();
+        am.setTonySession(session);
+        Assert.assertNull(
+                am.groupDependencyTimeout(conf)
+        );
+    }
+
+    private TonySession buildPartialTaskScheduledSession(Configuration conf) {
+        TonySession session = new TonySession.Builder().setTonyConf(conf).build();
+
+        TonySession.TonyTask worker0 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "0", "localhost");
+        TonySession.TonyTask worker1 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "1", "localhost");
+        TonySession.TonyTask worker2 = session.buildTonyTask(Constants.WORKER_JOB_NAME, "2", "localhost");
+
+        worker0.setTaskInfo();
+        worker1.setTaskInfo();
+        worker2.setTaskInfo();
+
+        session.addTask(worker0);
+        session.addTask(worker1);
+        session.addTask(worker2);
+
+        return session;
+    }
+
     private TonySession buildMockSession(Configuration tonyConf) {
         TonySession session = new TonySession.Builder().setTonyConf(tonyConf).build();
 


### PR DESCRIPTION
### Bug Fix

When some resources are not satisfied and the conf of dependency-timeout-check is specified, it will throw exception. like:

```
2021-12-09 06:18:04 INFO  ApplicationMaster:1199 - Successfully started container container_e03_1582553233674_1290236_01_000033
2021-12-09 06:18:04 ERROR TFRuntime:149 - Failed to check dependency timeout.
java.lang.NullPointerException
	at com.linkedin.tony.runtime.MLGenericRuntime.lambda$groupDependencyTimeout$1(MLGenericRuntime.java:211)
	at java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:227)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.LongPipeline.reduce(LongPipeline.java:443)
	at java.util.stream.LongPipeline.max(LongPipeline.java:406)
	at com.linkedin.tony.runtime.MLGenericRuntime.groupDependencyTimeout(MLGenericRuntime.java:212)
	at com.linkedin.tony.runtime.MLGenericRuntime.isHealthy(MLGenericRuntime.java:147)
	at com.linkedin.tony.ApplicationMaster.monitor(ApplicationMaster.java:749)
	at com.linkedin.tony.ApplicationMaster.run(ApplicationMaster.java:422)
	at com.linkedin.tony.ApplicationMaster.main(ApplicationMaster.java:356)
```

### Solution

To get the accurate running tasks info, we should make dependency-group-timeout check ignored until all tasks scheduled.

Tips:
I add the test case for above meeting problems, if you remove the `MLGenericRuntime.groupDependencyTimeout`, and then you could rerun this `testPartialTaskScheduledShouldPass` test case and reproduce the problem.
