### PR TITLE
Introduce the config of max-waiting-time when task executor register to AM

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -50,6 +50,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -903,7 +904,7 @@ public class ApplicationMaster {
         LOG.info("[" + taskId + "] Received Registration for HB !!");
         hbMonitor.register(task);
         killChiefWorkerIfTesting(taskId);
-        return "";
+        return StringUtils.EMPTY;
       }
       return null;
     }

--- a/tony-core/src/main/java/com/linkedin/tony/Framework.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Framework.java
@@ -66,7 +66,7 @@ public class Framework {
         boolean needReserveTBPort();
 
         default int executorPythonShell(TaskExecutor executor) throws IOException, InterruptedException {
-            return Utils.executeShell(executor.getTaskCommand(), executor.getTimeOut(), executor.getShellEnv());
+            return Utils.executeShell(executor.getTaskCommand(), executor.getExecutionTimeout(), executor.getShellEnv());
         }
     }
 }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -172,6 +172,9 @@ public class TonyConfigurationKeys {
   public static final String TASK_EXECUTION_TIMEOUT = TONY_TASK_PREFIX + "executor.execution-timeout-ms";
   public static final int DEFAULT_TASK_EXECUTION_TIMEOUT = 0;
 
+  public static final String TASK_EXECUTOR_MAX_REGISTRY_SEC = TONY_TASK_PREFIX + "executor.registry-timeout-sec";
+  public static final int DEFAULT_TASK_EXECUTOR_MAX_REGISTRY_SEC = 0;
+
   // AM configurations
   public static final String AM_PREFIX = TONY_PREFIX + "am.";
 

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -116,6 +116,10 @@ public class Utils {
     return pollTillConditionReached(func, Objects::nonNull, () -> null, interval, timeout);
   }
 
+  public static <T> T pollForeverTillNonNull(Callable<T> func, int interval) {
+    return pollTillNonNull(func, interval, 0);
+  }
+
   public static <T> T pollTillConditionReached(Callable<T> callFunc, Function<T, Boolean> conditionFunc,
           CallableWithoutException<T> defaultReturnedFunc, int interval, int timeout) {
     Preconditions.checkArgument(interval >= 0, "Interval must be non-negative.");

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -137,6 +137,12 @@
     <value>0</value>
   </property>
 
+  <property>
+    <description>Timeout, in seconds for the task executor registry to AM before exit.</description>
+    <name>tony.task.executor.registry-timeout-sec</name>
+    <value>0</value>
+  </property>
+
   <!-- AM configurations -->
   <property>
     <description>How many times a failed AM should retry.</description>


### PR DESCRIPTION
### Why
Introduce this config make that the max-registry-time in task executor can be configurable.

Besides, to solve the network failure, this PR make the rpc of `registerCallbackInfo` can retry multiple times.