### PR TITLE
Disable refreshMemoryBytesMetrics when running test cases on Mac

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskMonitor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskMonitor.java
@@ -107,6 +107,14 @@ class TaskMonitor implements Runnable {
   }
 
   private void refreshMemoryBytesMetrics() {
+    /**
+     * ProcfsBasedProcessTree currently is supported only on Linux.
+     * So when running test cases on Mac, the {@code resourceCalculator}
+     * is null and should be ignored.
+     */
+    if (resourceCalculator == null) {
+      return;
+    }
     resourceCalculator.updateProcessTree();
     double memoryBytes = resourceCalculator.getRssMemorySize();
     setMaxMetrics(MAX_MEMORY_BYTES_INDEX, memoryBytes);


### PR DESCRIPTION
Description:

Because ProcfsBasedProcessTree currently is supported only on Linux.
When running test cases on Mac, the resourceCalculator is null
and should be ignored.

Signed-off-by: zhangjunfan <junfan.zhang@outlook.com>