### PR TITLE
Check registrationTimeoutMs in advance to avoid decrease in efficiency

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -1326,9 +1326,13 @@ public class ApplicationMaster {
   }
 
   private boolean registrationTimeout() {
+    if (registrationTimeoutMs <= 0) {
+      return false;
+    }
+
     Set<TonyTask> unregisteredTasks = getUnregisteredTasks();
     for (TonyTask t : unregisteredTasks) {
-      if (registrationTimeoutMs <= 0 || System.currentTimeMillis() - t.getStartTime() <= registrationTimeoutMs) {
+      if (System.currentTimeMillis() - t.getStartTime() <= registrationTimeoutMs) {
         continue;
       }
 


### PR DESCRIPTION
Thanks for the great work, when monitoring the TensorFlow training job in `ApplicationMaster`, we can check `registrationTimeoutMs ` in advance to prevent decrease in efficiency.